### PR TITLE
BOJ_1929번 문제풀이

### DIFF
--- a/01. 수학/BOJ_1929/BOJ_1929/BOJ_1929.cpp
+++ b/01. 수학/BOJ_1929/BOJ_1929/BOJ_1929.cpp
@@ -1,0 +1,40 @@
+﻿
+
+#include <iostream>
+#include <cmath>
+#include <algorithm>
+
+using namespace std;
+const int MAX = 1000000;
+bool arr[MAX + 1];
+int M, N;
+
+void eratosthenes(int min, int max) {
+	arr[0] = false;
+	arr[1] = false;
+	for (int i = 2; i <=sqrt(N); i++)
+	{
+		if (arr[i]) {
+			for (int j = i * 2; j <= N; j += i) {
+				arr[j] = false;
+			}
+		}
+	}
+	for (int i = M; i <= N; i++)
+	{
+		if (arr[i]) {
+			cout << i << "\n";
+		}
+	}
+}
+
+int main()
+{
+	ios_base::sync_with_stdio(false);
+	cin.tie(NULL);
+	cout.tie(NULL);
+	memset(arr, true,sizeof(arr));
+	cin >> M >> N;
+	eratosthenes(M,N);
+	return 0;
+}


### PR DESCRIPTION
BOJ_1929번 문제풀이 / 소수찾기 / 에라토스테네스의 체를 사용한 소수 찾기
bool 배열을 초기화하는 과정에서 문제를 계속 틀림
memset을 이용한 초기화를 해줬다.  더 좋은 방법?