### PR TITLE
BOJ_1978번 문제풀이 / 수학

### DIFF
--- a/01. 수학/BOJ_1978_2/BOJ_1978_2/BOJ_1978_2.cpp
+++ b/01. 수학/BOJ_1978_2/BOJ_1978_2/BOJ_1978_2.cpp
@@ -1,0 +1,49 @@
+﻿
+#include <iostream>
+#include <cstring>
+#include <cmath>
+#include <vector>
+const int MAX = 1001;
+
+using namespace std;
+
+bool arr[MAX];
+
+int N;
+vector<int> v;
+
+void eratosthenes() {
+	memset(arr, true, sizeof(arr));
+	arr[0] = false;
+	arr[1] = false;
+	for (int i = 2; i <= sqrt(MAX); i++)
+	{
+		if (arr[i]) {
+			for (int j = i * 2; j < MAX; j += i)
+			{
+				arr[j] = false;
+			}
+		}
+	}
+}
+
+int main()
+{
+    cin >> N;
+	for (int i = 0; i < N; i++)
+	{
+		int temp;
+		cin >> temp;
+		v.push_back(temp);
+	}
+	eratosthenes();
+	int cnt = 0;
+	for (int i = 0; i < N; i++)
+	{
+		if (arr[v[i]]) {
+			cnt++;
+		}
+	}
+	cout << cnt << endl;
+}
+


### PR DESCRIPTION
에라토스테네스의 체를 이용한 문제 풀기

이전 풀이에서는 해당하는 숫자들의 대하여 소수인지를 판별했지만
이번에는 처음부터 최대값까지의 소수들을 전부 찾아놓고
주어진 수들을 검사해나가며 cnt를 올렸다.