### PR TITLE
BOJ_2798번 문제풀이 / 브루트포스

### DIFF
--- a/02. 브루트포스/BOJ_2798/BOJ_2798/BOJ_2798.cpp
+++ b/02. 브루트포스/BOJ_2798/BOJ_2798/BOJ_2798.cpp
@@ -1,0 +1,45 @@
+﻿
+
+#include <iostream>
+#include <algorithm>
+#include <vector>
+
+using namespace std;
+
+vector<int> v;
+vector<int> arr;
+int N, M;
+int res = -1;
+
+int main()
+{
+    cin >> N >> M;
+	for (int i = 0; i < N; i++)
+	{
+		int temp;
+		cin >> temp;
+		arr.push_back(temp);
+	}
+	for (int i = 0; i < N-3; i++)
+	{
+		v.push_back(0);
+	}for (int i = 0; i < 3; i++)
+	{
+		v.push_back(1);
+	}
+	do
+	{
+		int sum = 0;
+		for (int i = 0; i < N; i++)
+		{
+			if (v[i] == 1) {
+				sum += arr[i];
+			}
+		}
+		if (sum <= M) {
+			res = max(res, sum);
+		}
+	} while (next_permutation(v.begin(),v.end()));
+	cout << res;
+}
+


### PR DESCRIPTION
BOJ_2798번 문제풀이
순열을 이용해서 조합? 문제를 풀어보았다. 
이전의 3중for문을 이용한 것보다 처음에 세팅해주는 부분에서 for문이 여러번 돌아가서 인지
이전 풀이보다 시간이 느리게 나왔다. vector도 선언을 많이해서 메모리도 조금 더 먹음
브루트포스는 확실히 무식하게 푸는것이 좋을 때가 있는듯